### PR TITLE
docs: add Sphinx tutorials for UBC FENT20

### DIFF
--- a/docs/source/tutorials/adding-anthropic-provider.rst
+++ b/docs/source/tutorials/adding-anthropic-provider.rst
@@ -1,0 +1,120 @@
+Adding an Anthropic Provider to Smarter
+======================================
+
+Goal
+----
+
+Add Anthropic as an LLM provider in Smarter and register a Claude model so it can be used for coding-assistant workflows.
+
+Prerequisites
+-------------
+
+This tutorial assumes that you:
+
+* already have a working Smarter account
+* can sign in to the Smarter web console
+* already have an Anthropic API key
+* understand basic LLM terms such as provider, model, and API key
+* are comfortable following technical setup steps without screenshots
+
+Setup
+-----
+
+Before you begin, gather the following:
+
+* an Anthropic API key
+* the Claude model name you plan to register
+* the base endpoint information required by your Smarter deployment
+* the account permissions needed to manage providers
+
+Concept Overview
+----------------
+
+In Smarter, a **provider** is the external LLM service integration. A **model** is the individual model entry exposed by that provider.
+
+For this exercise:
+
+* **Provider** = Anthropic
+* **Model** = a Claude model that your team will use with Claude Code
+
+The high-level flow is:
+
+1. create or open the Anthropic provider entry
+2. store the API credential securely in Smarter
+3. register the Claude model under that provider
+4. validate the provider/model pairing
+5. use the model in downstream Smarter resources
+
+Step-by-Step
+------------
+
+1. Sign in to Smarter.
+
+2. Open the area used for provider management.
+
+3. Create a new provider entry, or select the existing Anthropic provider if one already exists.
+
+4. Enter the provider details required by your Smarter installation. At minimum, confirm the provider name, authentication details, and endpoint values expected by the form.
+
+5. Paste in the Anthropic API key and save it using the platform's credential handling workflow.
+
+6. Add a model record beneath the provider. Use a clear internal display name so programmers can identify it quickly.
+
+7. In the model configuration, enter the Claude model identifier required by your environment.
+
+8. Save the model.
+
+9. Run the provider or model verification check if your installation exposes one. Verification confirms that Smarter can reach the provider and that the configured model is compatible with the expected feature set.
+
+10. Confirm that the model now appears as an available option inside the relevant Smarter resource or authoring workflow.
+
+Recommended Naming Convention
+-----------------------------
+
+Use a simple naming convention so your team can distinguish provider records from model records.
+
+Example:
+
+* Provider display name: ``Anthropic``
+* Model display name: ``Claude Code - Team Standard``
+* Optional technical alias: ``anthropic-claude-code``
+
+Proof of Concept
+----------------
+
+A successful proof of concept is simple:
+
+* the Anthropic provider saves without credential errors
+* the Claude model saves successfully
+* the model passes validation
+* the model appears as a selectable LLM option in Smarter
+
+One practical smoke test is to open a coding-oriented prompt or resource and confirm that the Claude model can be selected and invoked.
+
+Troubleshooting
+---------------
+
+**Problem: The provider saves, but the model does not validate.**
+
+Check that the model identifier exactly matches the Claude model name expected by your Smarter deployment.
+
+**Problem: Authentication fails.**
+
+Re-enter the Anthropic API key and confirm that the key is active and not restricted incorrectly.
+
+**Problem: The model is not visible to programmers.**
+
+Check account permissions, provider visibility, and whether the model was attached to the correct account or scope.
+
+**Problem: The provider exists, but requests still fail.**
+
+Re-check the endpoint configuration and run the platform verification step again.
+
+**Problem: The UI looks different from this tutorial.**
+
+The Smarter Provider app is under active development. Use this tutorial as the process guide, but follow the labels and controls shown in your current deployment.
+
+Expected Outcome
+----------------
+
+At the end of this tutorial, your Smarter environment should expose an Anthropic-backed Claude model that programmers can use in Smarter-based coding workflows.

--- a/docs/source/tutorials/getting-started-claude-code-with-smarter.rst
+++ b/docs/source/tutorials/getting-started-claude-code-with-smarter.rst
@@ -1,0 +1,141 @@
+Getting Started with Claude Code in Smarter
+===========================================
+
+Goal
+----
+
+Use Claude Code through Smarter to support virtual coding-pair workflows for the custom programming team.
+
+Prerequisites
+-------------
+
+This guide assumes that the reader:
+
+* already has a Smarter account and can log in
+* already has access to an Anthropic-backed Claude model in Smarter
+* understands basic software development workflow concepts
+* can work with source control and a local terminal
+* can interpret LLM output critically rather than accepting it blindly
+
+Setup
+-----
+
+Before starting, confirm the following:
+
+* your Smarter account is active
+* Anthropic has been added as a provider in Smarter
+* a Claude model has been registered and validated
+* your local development project is available in git
+* you understand your team's coding, security, and review standards
+
+Concept Overview
+----------------
+
+Smarter acts as the managed platform layer for LLM access. It centralizes model access, credentials, and model availability. Claude Code is the model-assisted coding experience used by the programming team.
+
+In practical terms, programmers are not onboarding a raw model directly. They are using a Claude model that has already been exposed through Smarter.
+
+This matters because it gives the team:
+
+* a common entry point for approved models
+* centralized credential handling
+* repeatable onboarding
+* a shared way to test and compare model behavior
+
+Step-by-Step
+------------
+
+1. Sign in to Smarter.
+
+2. Confirm that the approved Claude model is visible in the model or provider selection area.
+
+3. Open the relevant authoring, prompt, or coding workflow in Smarter.
+
+4. Select the approved Claude model.
+
+5. Define a small, low-risk programming task for your first run. Good examples include:
+
+   * generate a utility function
+   * refactor a small method
+   * write unit-test scaffolding
+   * explain an unfamiliar code block
+
+6. Give the model enough technical context to do useful work. Include:
+
+   * the programming language
+   * the desired output format
+   * constraints such as style, framework, and security requirements
+   * a short success criterion
+
+7. Review the output carefully. Do not treat the first answer as production-ready.
+
+8. Test the generated code locally.
+
+9. Refine the prompt and rerun as needed.
+
+10. Commit only the code that passes your normal engineering review standard.
+
+Prompt Pattern
+--------------
+
+A simple starter pattern is:
+
+::
+
+   Task: Write a Python helper function.
+   Context: This function will be used in our internal service.
+   Requirements:
+   - Python 3.13
+   - add docstring
+   - handle invalid input safely
+   - include one example test case
+   Output: code only
+
+Proof of Concept
+----------------
+
+Use a concrete coding task such as the following:
+
+* ask Claude to generate a small helper function
+* copy the result into your local project
+* run the code or test
+* confirm that it behaves as expected
+
+A successful proof of concept is not just "the model answered." A successful proof of concept means the model produced code that is understandable, testable, and usable after human review.
+
+Troubleshooting
+---------------
+
+**Problem: The Claude model is missing.**
+
+Confirm that the Anthropic provider and Claude model were created and validated in Smarter.
+
+**Problem: The output is too vague.**
+
+Add more context. State the language, framework, expected format, and acceptance criteria.
+
+**Problem: The code looks correct but fails locally.**
+
+Treat the output as a draft. Debug it, add tests, and rerun with tighter constraints.
+
+**Problem: Different developers get inconsistent results.**
+
+Standardize prompts, define shared model defaults, and keep proof-of-concept tasks narrowly scoped.
+
+**Problem: The model suggests insecure or non-compliant code.**
+
+Reject the output, restate your security constraints explicitly, and apply normal peer review before merging any change.
+
+Best Practices
+--------------
+
+* start with small tasks
+* prefer explicit prompts over vague requests
+* verify every code suggestion
+* keep humans in the review loop
+* use git normally: branch, test, review, commit, and push
+
+Expected Outcome
+----------------
+
+At the end of this tutorial, a programmer should be able to sign in to Smarter, select the approved Claude model, complete a small coding task, validate the output locally, and continue using the workflow as a virtual coding pair.


### PR DESCRIPTION
This pull request adds two Sphinx reStructuredText tutorials for the FENT20 capstone project:

1. Adding Anthropic as an LLM provider
2. Getting started with Claude Code in Smarter

These docs are intended as self-onboarding materials for a technically proficient programming audience.